### PR TITLE
Correct comment to avoid error on android 8

### DIFF
--- a/android/src/main/assets/SearchWebView.js
+++ b/android/src/main/assets/SearchWebView.js
@@ -1,7 +1,7 @@
 var MyApp_SearchResultCount = 0;
 
 function MyApp_HighlightAllOccurencesOfStringForElement(element, keyword, color, doc) {
-  // Using try catch block to avoid error when trying to access contentDocument
+  /* Using try catch block to avoid error when trying to access contentDocument */
   try {
     if (element) {
       if (element.nodeType == 3) {
@@ -52,7 +52,7 @@ function MyApp_ScrollToHighlightTop() {
 }
 
 function MyApp_RemoveAllHighlightsForElement(element) {
-  // Using try catch block to avoid error when trying to access contentDocument
+  /* Using try catch block to avoid error when trying to access contentDocument */
   try {
     if (element) {
       if ((element.nodeType == 1) && (element.tagName.toLowerCase() == "iframe") && (element.contentDocument != null)) {


### PR DESCRIPTION
In Android 8, it read content of the js file as a single line. It causes `//` comment syntax comment out all valid source after the comment line.