### PR TITLE
handle webview HitTestResult when it hit image url and web url is null

### DIFF
--- a/android/src/main/java/com/phoebe/pbwebview/PBWebViewManager.java
+++ b/android/src/main/java/com/phoebe/pbwebview/PBWebViewManager.java
@@ -651,6 +651,7 @@ public class PBWebViewManager extends SimpleViewManager<WebView> {
                 if (type == HitTestResult.SRC_ANCHOR_TYPE) {
                   image_url = "";
                 }
+                // when any downloaded image file is showing in webview - https://github.com/lunascape/react-native-wkwebview/pull/45
                 if (type == HitTestResult.IMAGE_TYPE && url == null) {
                   url = image_url;
                 }

--- a/android/src/main/java/com/phoebe/pbwebview/PBWebViewManager.java
+++ b/android/src/main/java/com/phoebe/pbwebview/PBWebViewManager.java
@@ -659,7 +659,6 @@ public class PBWebViewManager extends SimpleViewManager<WebView> {
                 data.putString("type", "contextmenu");
                 data.putString("url", url);
                 data.putString("image_url", image_url);
-                System.out.println(data);
                 dispatchEvent(webView, PBWebViewEvent.createMessageEvent(webView.getId(), data));
               }
             }

--- a/android/src/main/java/com/phoebe/pbwebview/PBWebViewManager.java
+++ b/android/src/main/java/com/phoebe/pbwebview/PBWebViewManager.java
@@ -645,16 +645,20 @@ public class PBWebViewManager extends SimpleViewManager<WebView> {
             public void handleMessage(Message msg) {
               String url = (String) msg.getData().get("url");
               String image_url = extra;
-              if (url == null) {
+              if (url == null && image_url == null) {
                 super.handleMessage(msg);
               } else {
                 if (type == HitTestResult.SRC_ANCHOR_TYPE) {
                   image_url = "";
                 }
+                if (type == HitTestResult.IMAGE_TYPE && url == null) {
+                  url = image_url;
+                }
                 WritableMap data = Arguments.createMap();
                 data.putString("type", "contextmenu");
                 data.putString("url", url);
                 data.putString("image_url", image_url);
+                System.out.println(data);
                 dispatchEvent(webView, PBWebViewEvent.createMessageEvent(webView.getId(), data));
               }
             }


### PR DESCRIPTION
Related to issue https://github.com/lunascape/phoebe-mobile/issues/1003

The problem was when it hit local image files saved in file manager, the `URL` is null, only `image URL` is there, so it was not showing the context menu. 

Solution: When hit `IMAGE_TYPE` and if `URL == null`, then make  `URL == IMAGE_TYPE`