### PR TITLE
remove CFBundleIdentifier for fastlane app transport error

### DIFF
--- a/ios/RCTWKWebView/RCTWKWebView.m
+++ b/ios/RCTWKWebView/RCTWKWebView.m
@@ -506,6 +506,7 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithCoder:(NSCoder *)aDecoder)
                                                                                                  @"title": _webView.title,
                                                                                                  @"canGoBack": @(_webView.canGoBack),
                                                                                                  @"canGoForward" : @(_webView.canGoForward),
+                                                                                                 @"progress" : @(_webView.estimatedProgress),
                                                                                                  }];
   
   return event;

--- a/ios/Scripts/Info.plist
+++ b/ios/Scripts/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
This PR also fix - After the migration to new wkwebview version, webview was not sending the loading progress details in react-native layer. 